### PR TITLE
Add build and deploy to GH pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy PDF
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref to build
+        required: false
+        default: main
+
+env:
+  TEXLIVE_IMG_VERSION: 20250401
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || 'main' }}
+
+      - name: Build
+        uses: xu-cheng/latex-action@3.2.0
+        with:
+          root_file: hands4hire_doc.tex
+          docker_image: ghcr.io/xu-cheng/texlive-full:${{ env.TEXLIVE_IMG_VERSION }}
+
+      - name: Copy
+        run: |
+          mkdir out
+          cp ./hands4hire_doc.pdf ./out/docs.pdf
+
+      - name: Add index.html
+        run: |
+          echo '<object data="https://25l-ersms.github.io/documentation/docs.pdf" type="application/pdf" width="100%" height="100%">
+          <embed src="https://docs.google.com/viewer?url=https://25l-ersms.github.io/documentation/docs.pdf" type="application/pdf" width="100%" height="100%">
+          </object>' > out/index.html
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs
+          path: out/docs.pdf
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4.7.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: true
+          folder: out
+          git-config-name: ersms-bot
+          git-config-email: bot@noreply.ersms.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# ERSMS docs
+
+[![Deploy PDF](https://github.com/25l-ersms/documentation/actions/workflows/pages.yml/badge.svg)](https://github.com/25l-ersms/documentation/actions/workflows/pages.yml) [![pages-build-deployment](https://github.com/25l-ersms/documentation/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/25l-ersms/documentation/actions/workflows/pages/pages-build-deployment)
+
+**Grab the latest PDF [> here <](https://25l-ersms.github.io/documentation/)**
+
+### Build locally
+
+Compile using `pdflatex`:
+
+```shell
+pdflatex hands4hire_doc.tex
+```


### PR DESCRIPTION
- GA builds the PDF and deploys to GH Pages on every commit to `main`
- If needed, the workflow can run from a specified ref
- Latest PDF is always available here: https://25l-ersms.github.io/documentation/